### PR TITLE
feat: Update mod version to 1.0.2 and enhance crop experience configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ yarn_mappings=1.21.4+build.8
 loader_version=0.16.10
 
 # Mod Properties
-mod_version=1.0.1
+mod_version=1.0.2
 maven_group=com.jlucaso.cultivatorsreward
 archives_base_name=cultivatorsreward
 

--- a/src/main/java/com/jlucaso/cultivatorsreward/CultivatorsReward.java
+++ b/src/main/java/com/jlucaso/cultivatorsreward/CultivatorsReward.java
@@ -1,22 +1,32 @@
 package com.jlucaso.cultivatorsreward;
 
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
-import net.fabricmc.loader.api.FabricLoader;
-import net.minecraft.block.CropBlock;
-import net.minecraft.server.network.ServerPlayerEntity;
+import java.util.Random;
 
-import net.fabricmc.fabric.api.event.Event;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.jlucaso.cropharvestserver.event.CropHarvestedCallback;
-import com.jlucaso.cultivatorsreward.config.CultivatorsConfig;
 import com.jlucaso.cultivatorsreward.config.ModConfig;
 
+import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.event.Event;
+import net.fabricmc.fabric.api.event.player.PlayerBlockBreakEvents;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.registry.Registries;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
+
 public class CultivatorsReward implements ModInitializer {
+    public static final String MOD_ID = "cultivatorsreward";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    private final Random random = new Random();
+    private ModConfig config;
+
     @Override
     public void onInitialize() {
-        ModConfig config = ModConfig.register();
-        CultivatorsConfig.bonusXp = config.bonusXp;
+        this.config = ModConfig.register();
 
         // COMPATIBILITY WITH cropharvestserver mod
         FabricLoader.getInstance().getModContainer("cropharvestserver").ifPresent(modContainer -> {
@@ -25,23 +35,73 @@ public class CultivatorsReward implements ModInitializer {
                     .getObjectShare()
                     .get(CropHarvestedCallback.EVENT_KEY);
             if (sharedEvent != null) {
-                sharedEvent.register(
-                        (CropHarvestedCallback) (player, blockPos, state, blockEntity) -> {
-                            if (player instanceof ServerPlayerEntity) {
-                                ((ServerPlayerEntity) player).addExperience(CultivatorsConfig.bonusXp);
-                            }
-                        });
-
+                LOGGER.info("Cropharvestserver mod detected, registering shared event.");
+                sharedEvent.register((player, serverWorld, blockPos, blockState) -> {
+                    addCropExperience((ServerPlayerEntity) player, blockState);
+                });
             }
         });
 
         PlayerBlockBreakEvents.BEFORE.register((world, player, pos, state, blockEntity) -> {
             if (!world.isClient() && state.getBlock() instanceof CropBlock crop && crop.isMature(state)) {
-                if (player instanceof ServerPlayerEntity) {
-                    ((ServerPlayerEntity) player).addExperience(CultivatorsConfig.bonusXp);
+                if (player instanceof ServerPlayerEntity serverPlayerEntity) {
+                    addCropExperience(serverPlayerEntity, state);
                 }
             }
             return true;
         });
+    }
+
+    private void addCropExperience(ServerPlayerEntity player, BlockState state) {
+        // Get primary crop identifier
+        Identifier blockId = Registries.BLOCK.getId(state.getBlock());
+        String cropId = blockId.toString();
+
+        // Get chance and check if we should add XP
+        int xpChance = getConfigValue(cropId, this.config.cropSpecificXpChance, this.config.xpChance);
+        if (random.nextInt(100) >= xpChance) {
+            return;
+        }
+
+        // Get XP amount and add to player
+        int xpAmount = getConfigValue(cropId, this.config.cropSpecificXp, this.config.bonusXp);
+        player.addExperience(xpAmount);
+    }
+
+    /**
+     * Helper method to get a config value for a crop, with fallbacks
+     * 
+     * @param <T>          The type of the value
+     * @param cropId       The primary crop identifier
+     * @param configMap    The config map to look in
+     * @param defaultValue The default value if no match is found
+     * @return The config value
+     */
+    private <T> T getConfigValue(String cropId, java.util.Map<String, T> configMap, T defaultValue) {
+        // Direct lookup
+        if (configMap.containsKey(cropId)) {
+            return configMap.get(cropId);
+        }
+
+        // Try alternative ID from translation key
+        String translationKey = Registries.BLOCK.get(Identifier.tryParse(cropId)).getTranslationKey();
+        String[] parts = translationKey.split("\\.");
+        if (parts.length >= 3) {
+            String altCropId = parts[1] + ":" + parts[2];
+            if (configMap.containsKey(altCropId)) {
+                return configMap.get(altCropId);
+            }
+        }
+
+        // Try matching by crop name
+        String cropName = cropId.substring(cropId.lastIndexOf(':') + 1);
+        for (String key : configMap.keySet()) {
+            if (key.contains(cropName)) {
+                return configMap.get(key);
+            }
+        }
+
+        // Return default if no match found
+        return defaultValue;
     }
 }

--- a/src/main/java/com/jlucaso/cultivatorsreward/config/CultivatorsConfig.java
+++ b/src/main/java/com/jlucaso/cultivatorsreward/config/CultivatorsConfig.java
@@ -1,5 +1,0 @@
-package com.jlucaso.cultivatorsreward.config;
-
-public class CultivatorsConfig {
-    public static int bonusXp = 1;
-}

--- a/src/main/java/com/jlucaso/cultivatorsreward/config/ModConfig.java
+++ b/src/main/java/com/jlucaso/cultivatorsreward/config/ModConfig.java
@@ -1,18 +1,32 @@
 package com.jlucaso.cultivatorsreward.config;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import com.jlucaso.cultivatorsreward.CultivatorsReward;
+
 import me.shedaniel.autoconfig.AutoConfig;
 import me.shedaniel.autoconfig.ConfigData;
 import me.shedaniel.autoconfig.annotation.Config;
-import me.shedaniel.autoconfig.serializer.Toml4jConfigSerializer;
+import me.shedaniel.autoconfig.serializer.GsonConfigSerializer;
 import me.shedaniel.cloth.clothconfig.shadowed.blue.endless.jankson.Comment;
 
-@Config(name = "cultivators-reward")
+@Config(name = CultivatorsReward.MOD_ID)
 public class ModConfig implements ConfigData {
-    @Comment("Amount of bonus XP given when harvesting crops (default: 1)")
+    @Comment("Default amount of bonus XP given when harvesting crops (default: 1)")
     public int bonusXp = 1;
 
+    @Comment("Chance percentage to receive XP when harvesting crops (0-100, default: 100)")
+    public int xpChance = 100;
+
+    @Comment("Specific XP rewards for different crops. Format: 'modid:cropname'")
+    public Map<String, Integer> cropSpecificXp = new HashMap<>();
+
+    @Comment("Specific XP chances for different crops. Format: 'modid:cropname'")
+    public Map<String, Integer> cropSpecificXpChance = new HashMap<>();
+
     public static ModConfig register() {
-        AutoConfig.register(ModConfig.class, Toml4jConfigSerializer::new);
+        AutoConfig.register(ModConfig.class, GsonConfigSerializer::new);
         return AutoConfig.getConfigHolder(ModConfig.class).getConfig();
     }
 }


### PR DESCRIPTION
possibility to configure xp and chance of get xp per crop (fallback to default values).

Example of config:
`cultivators-reward.json` -> needed to change to json format, toml is getting error when trying to use map
```json
{
  "bonusXp": 1,
  "xpChance": 100,
  "cropSpecificXp": {
    "minecraft:carrots": 5,
    "minecraft:wheat": 10
  },
  "cropSpecificXpChance": {
    "minecraft:carrots": 50,
    "minecraft:wheat": 50
  }
}
```

Close https://github.com/jlucaso1/cultivators-reward/issues/2